### PR TITLE
Change folder name

### DIFF
--- a/gamesmenu.sh
+++ b/gamesmenu.sh
@@ -36,7 +36,7 @@ MGL_MAP = (
     ("Genesis", "_Console/Genesis", (({".bin", ".gen", ".md"}, 1, "f", 0),)),
     ("MegaCD", "_Console/MegaCD", (({".cue", ".chd"}, 1, "s", 0),)),
     (
-        "NeoGeo",
+        "NEOGEO",
         "_Console/NeoGeo",
         (({".neo", ".zip"}, 1, "f", 1), ({".iso", ".bin"}, 1, "s", 1)),
     ),


### PR DESCRIPTION
Script still couldn't see the Neo Geo games when I got the .neo pack. Tried changing the folder name to match what I've got, and it worked. To make sure my folder name didn't get wonky, I renamed it and re-ran update-all, and it downloaded the folder as "NEOGEO". So I believe that's the current naming scheme, despite what the Neo Geo core's README says.