### PR TITLE
C64 core: support for disk and tape images

### DIFF
--- a/gamesmenu.sh
+++ b/gamesmenu.sh
@@ -31,7 +31,14 @@ MGL_MAP = (
         (({".car", ".a52", ".bin", ".rom"}, 1, "s", 1),),
     ),
     ("AtariLynx", "_Console/AtariLynx", (({".lnx"}, 1, "f", 0),)),
-    ("C64", "_Computer/C64", (({".prg", ".crt", ".reu", ".tap"}, 1, "f", 1),)),
+    (
+        "C64",
+        "_Computer/C64",
+        (
+            ({".prg", ".crt", ".reu", ".tap"}, 1, "f", 1),
+            ({".d64", ".t64", ".g64", ".d81"}, 1, "s", 0),
+        ),
+    ),
     ("ChannelF", "_Console/ChannelF", (({".rom", ".bin"}, 1, "f", 1),)),
     (
         "Coleco",


### PR DESCRIPTION
Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced C64 emulation to recognize additional disk-image file formats for improved compatibility with existing game libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->