### PR TITLE
Fixed bug that would set some defaults for selected wrong

### DIFF
--- a/gamesmenu.sh
+++ b/gamesmenu.sh
@@ -338,7 +338,7 @@ def display_menu(system_paths):
         display_name = get_names_replacement(name)
 
         if os.path.exists(
-                os.path.join(GAMES_MENU_PATH, folder_name(display_name))
+                os.path.join(GAMES_MENU_PATH, folder_name(name))
         ) or not os.path.exists(GAMES_MENU_PATH):
             selected = True
         else:


### PR DESCRIPTION
folder_name(display_name) calls get_names_replacement(display_name), so because display_name was already replaced with a new name from names.txt it will replace this name again if there is an entry in names.txt for the it, and then it would search for a folder with that name instead of searching for the one with the system's display name. 

This bug can be seen with the update_all names.txt with the us common names setting, as "MegaDrive" will be replaced with "Genesis", which also has an entry that replaces it with "Genesis +",  which is then searched for despite it not being the folder that gets created when the script is run. If you have a "_Genesis +" folder then the MegaDrive selection is defaulted to on, and if you don't it is defaulted to off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed system entries in the games menu so their selected state now matches the correct folder already present on disk.
  * Menu items that use renamed display labels will now be recognized more reliably as already configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->